### PR TITLE
Send zaps to user profile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@scure/bip39": "^1.1.1",
         "@twogate/ngx-photo-gallery": "^1.4.0",
         "@types/sharedworker": "^0.0.91",
+        "angularx-qrcode": "^15.0.1",
         "dexie": "^3.2.3",
         "html5-qrcode": "^2.3.7",
         "idb": "^7.1.1",
@@ -4293,8 +4294,7 @@
     "node_modules/@types/node": {
       "version": "18.11.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
-      "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==",
-      "dev": true
+      "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng=="
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -4306,7 +4306,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.0.tgz",
       "integrity": "sha512-x5ilHXRxUPIMfjtM+1vf/GPTRWZ81nqscursm5gMznJeK9M0YnZ1c3bEvRLQ0zSSgedLx1J6MGL231ObQGGhaA==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -4714,6 +4713,19 @@
       },
       "peerDependencies": {
         "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/angularx-qrcode": {
+      "version": "15.0.1",
+      "resolved": "https://inditex.jfrog.io/inditex/api/npm/node-public/angularx-qrcode/-/angularx-qrcode-15.0.1.tgz",
+      "integrity": "sha512-CirpL2rhhYX/QZ1OSaJ/fusABjDlwl1oYBqaLRqmyie0xTbscWqTBW0DEoht2yCNGN8Wt+JmZwTLxYG6tLuWeQ==",
+      "dependencies": {
+        "@types/qrcode": "1.5.0",
+        "qrcode": "1.5.1",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "^15.0.0"
       }
     },
     "node_modules/ansi-colors": {
@@ -15996,8 +16008,7 @@
     "@types/node": {
       "version": "18.11.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
-      "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==",
-      "dev": true
+      "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng=="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -16009,7 +16020,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.0.tgz",
       "integrity": "sha512-x5ilHXRxUPIMfjtM+1vf/GPTRWZ81nqscursm5gMznJeK9M0YnZ1c3bEvRLQ0zSSgedLx1J6MGL231ObQGGhaA==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -16377,6 +16387,16 @@
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.3"
+      }
+    },
+    "angularx-qrcode": {
+      "version": "15.0.1",
+      "resolved": "https://inditex.jfrog.io/inditex/api/npm/node-public/angularx-qrcode/-/angularx-qrcode-15.0.1.tgz",
+      "integrity": "sha512-CirpL2rhhYX/QZ1OSaJ/fusABjDlwl1oYBqaLRqmyie0xTbscWqTBW0DEoht2yCNGN8Wt+JmZwTLxYG6tLuWeQ==",
+      "requires": {
+        "@types/qrcode": "1.5.0",
+        "qrcode": "1.5.1",
+        "tslib": "^2.3.0"
       }
     },
     "ansi-colors": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@scure/bip39": "^1.1.1",
     "@twogate/ngx-photo-gallery": "^1.4.0",
     "@types/sharedworker": "^0.0.91",
+    "angularx-qrcode": "^15.0.1",
     "dexie": "^3.2.3",
     "html5-qrcode": "^2.3.7",
     "idb": "^7.1.1",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -141,6 +141,9 @@ import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 export function HttpLoaderFactory(http: HttpClient): TranslateHttpLoader {
   return new TranslateHttpLoader(http);
 }
+import { ZapDialogComponent } from './shared/zap-dialog/zap-dialog.component';
+import { QRCodeModule } from 'angularx-qrcode';
+import { ZapQrCodeComponent } from './shared/zap-qr-code/zap-qr-code.component';
 
 @NgModule({
   declarations: [
@@ -226,6 +229,8 @@ export function HttpLoaderFactory(http: HttpClient): TranslateHttpLoader {
     QrScanDialog,
     ContentEditorDirective,
     ContentInputHeightDirective,
+    ZapQrCodeComponent,
+    ZapDialogComponent
   ],
   imports: [
     AboutModule,
@@ -284,6 +289,7 @@ export function HttpLoaderFactory(http: HttpClient): TranslateHttpLoader {
     NgxMatNativeDateModule,
     NgxMatTimepickerModule,
     NgxColorsModule,
+    QRCodeModule,
     ServiceWorkerModule.register('ngsw-worker.js', {
       enabled: !isDevMode(),
       // enabled: true,

--- a/src/app/services/interfaces.ts
+++ b/src/app/services/interfaces.ts
@@ -327,3 +327,27 @@ export interface BlogEvent {
 
   published_at?: number;
 }
+export interface LNURLPayRequest {
+  allowsNostr?: boolean
+  nostrPubkey?: string;
+  minSendable?: number;
+  maxSendable?: number;
+  metadata?: string;
+  callback: string;
+  commentAllowed?: number;
+  status?: string
+}
+
+export interface LNURLPayResponse {
+  pr: string
+}
+
+export interface LNURLInvoice {
+  pr: string;
+  successAction?: LNURLSuccessAction;
+}
+
+export interface LNURLSuccessAction {
+  description?: string;
+  url?: string;
+}

--- a/src/app/services/utilities.ts
+++ b/src/app/services/utilities.ts
@@ -186,6 +186,12 @@ export class Utilities {
     return this.arrayToHex(key);
   }
 
+  convertBech32ToText(str: string) {
+    const decoded = bech32.decode(str, 1000);
+    const buf = bech32.fromWords(decoded.words);
+    return new TextDecoder().decode(Uint8Array.from(buf));
+  }
+  
   keyToHex(publicKey: Uint8Array) {
     return secp.utils.bytesToHex(publicKey);
   }

--- a/src/app/shared/profile-header/profile-header.html
+++ b/src/app/shared/profile-header/profile-header.html
@@ -68,7 +68,7 @@
         </div>
         <!-- <div class="profile-labels-right"></div> -->
       </div>
-      <div class="profile-labels" *ngIf="profile.lud06" [mtxTooltip]="tooltipTpl" [mtxTooltipPosition]="'left'">
+      <div class="profile-labels"  (click)="openDialog(profile)" *ngIf="profile.lud06" [mtxTooltip]="tooltipTpl" [mtxTooltipPosition]="'left'">
         <div class="profile-labels-left"><mat-icon class="profile-icon-custom">⚡️</mat-icon></div>
         <div class="profile-labels-middle dimmed">
           <!-- <a class="dimmed lightning-link" (click)="toggleLn()" *ngIf="profile.lud16 && paymentVersion == 'lud16'" [href]="utilities.sanitize('lightning:' + profile.lud16)">{{ profile.lud16 }}</a> -->
@@ -76,7 +76,7 @@
         </div>
         <!-- <div class="profile-labels-right"></div> -->
       </div>
-      <div class="profile-labels" *ngIf="profile.lud16" [mtxTooltip]="tooltipTpl2" [mtxTooltipPosition]="'left'">
+      <div class="profile-labels"  (click)="openDialog(profile)" *ngIf="profile.lud16" [mtxTooltip]="tooltipTpl2" [mtxTooltipPosition]="'left'">
         <div class="profile-labels-left"><mat-icon class="profile-icon-custom">⚡️</mat-icon></div>
         <div class="profile-labels-middle dimmed">
           <!-- <a class="dimmed lightning-link" (click)="toggleLn()" *ngIf="profile.lud16 && paymentVersion == 'lud16'" [href]="utilities.sanitize('lightning:' + profile.lud16)">{{ profile.lud16 }}</a> -->

--- a/src/app/shared/profile-header/profile-header.ts
+++ b/src/app/shared/profile-header/profile-header.ts
@@ -10,6 +10,7 @@ import { Subscription } from 'rxjs';
 import { UIService } from 'src/app/services/ui';
 import { ApplicationState } from 'src/app/services/applicationstate';
 import { nip05 } from 'nostr-tools';
+import { ZapDialogComponent } from '../zap-dialog/zap-dialog.component';
 
 @Component({
   selector: 'app-profile-header',
@@ -148,4 +149,14 @@ export class ProfileHeaderComponent {
     const url = `https://${values[1]}/.well-known/nostr.json?name=${values[0]}`;
     return url;
   }
+
+  openDialog(profile?: NostrProfileDocument): void {
+    this.dialog.open(ZapDialogComponent, {
+      width: '400px',
+      data: {
+        profile: profile
+      },
+    });
+  }
+
 }

--- a/src/app/shared/zap-dialog/zap-dialog.component.html
+++ b/src/app/shared/zap-dialog/zap-dialog.component.html
@@ -1,0 +1,112 @@
+<div mat-dialog-content>
+  <div class="profile-container">
+    <div class="icon icon-small">
+      <img
+        onerror="this.src='/assets/profile.png'"
+        *ngIf="profile?.status == 1 || profile?.status == 2"
+        class="profile-image profile-image-follow"
+        [matTooltip]="tooltip"
+        matTooltipPosition="above"
+        [src]="imagePath"
+      />
+      <img loading="lazy" onerror="this.src='/assets/profile.png'" *ngIf="profile?.status != 1 && profile?.status != 2" class="profile-image" [matTooltip]="tooltip" matTooltipPosition="above" [src]="imagePath" />
+    </div>
+    <div class="name clickable">
+      <span [class.muted]="profile.status == 2" [matTooltip]="tooltipName" matTooltipPosition="above">{{ profileName }}</span>
+    </div>
+  </div>
+  <div class="emoji-container">
+    <div class="emoji-button">
+      <button (click)="setAmount(500)" class="thumb-up-btn" mat-icon-button color="primary">
+        <mat-icon>thumb_up</mat-icon><span class="emoji-number">500</span>
+      </button>
+    </div>
+    <div class="emoji-button">
+      <button (click)="setAmount(1000)" class="favorite-btn" mat-icon-button color="primary">
+        <mat-icon>favorite</mat-icon><span class="emoji-number">1k</span>
+      </button>
+    </div>
+    <div class="emoji-button">
+      <button (click)="setAmount(10000)" class="applause-btn" mat-icon-button color="primary">
+        <mat-icon>rocket</mat-icon><span class="emoji-number">10k</span>
+      </button>
+    </div>
+  </div>
+  
+
+
+  <form [formGroup]="sendZapForm" (ngSubmit)="onSubmit()" novalidate>
+    <div class="row">
+      <div class="col">
+        <mat-form-field appearance="fill">
+          <mat-label>Zap Amount</mat-label>
+          <input
+            type="number"
+            matInput
+            formControlName="amount"
+            [(ngModel)]="amount"
+            placeholder="Enter Zap Amount"
+            step="1"
+            required
+          />
+          <mat-error *ngIf="sendZapForm.get('amount')?.invalid">
+            <ng-container [ngTemplateOutlet]="minSendable > 0 && maxSendable > 0 ? first : 
+              minSendable > 0 && maxSendable == 0 ? second : 
+              minSendable == 0 && maxSendable > 0 ? third :
+              maxSendable > 0 ? forth : 
+              maxSendable <= 0 ? fifth : sixth">
+            </ng-container>
+
+            <ng-template #first><span>Please enter an amount between {{minSendable}} and {{maxSendable}}.</span></ng-template>
+            <ng-template #second>The minimum amount you can send is {{minSendable}}.</ng-template>
+            <ng-template #third>The maximum amount you can send is {{maxSendable}}.</ng-template>
+            <ng-template #forth>The maximum amount you can send is {{maxSendable}}.</ng-template>
+            <ng-template #fifth>The maximum amount you can send is {{maxSendable}}.</ng-template>
+            <ng-template #sixth>Please enter a valid amount.</ng-template>
+          </mat-error>
+        </mat-form-field>
+      </div>
+      
+    </div>
+    <div class="row">
+      <div class="col">
+        <mat-form-field appearance="fill">
+          <mat-label>Comment</mat-label>
+          <input
+            matInput
+            type="text"
+            formControlName="comment"
+            placeholder="Enter Comment"
+          />
+          <mat-error *ngIf="sendZapForm.get('comment')?.invalid">
+            Please enter a comment.
+          </mat-error>
+        </mat-form-field>
+      </div>
+    </div>
+    <div mat-dialog-actions class="d-flex justify-content-between">
+      <div style="margin-right: 10px;">
+        <button mat-stroked-button mat-dialog-close color="primary">Cancel</button>
+      </div>
+      <div>
+        <button
+          mat-raised-button
+          color="primary"
+          class="zap-button"
+          [disabled]="sendZapForm.invalid"
+        >
+          <svg width="16" height="20" viewBox="0 0 16 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M8.8333 1.70166L1.41118 10.6082C1.12051 10.957 0.975169 11.1314 0.972948 11.2787C0.971017 11.4068 1.02808 11.5286 1.12768 11.6091C1.24226 11.7017 1.46928 11.7017 1.92333 11.7017H7.99997L7.16663 18.3683L14.5888 9.46178C14.8794 9.11297 15.0248 8.93857 15.027 8.79128C15.0289 8.66323 14.9719 8.54141 14.8723 8.46092C14.7577 8.36833 14.5307 8.36833 14.0766 8.36833H7.99997L8.8333 1.70166Z" stroke="currentColor" stroke-width="1.66667" stroke-linecap="round" stroke-linejoin="round">
+            </path>
+          </svg>
+          <span> Zap {{ sendZapForm.value.amount }}</span>
+        </button>
+      </div>
+    </div>
+
+    <mat-error *ngIf="error">
+      {{error}}
+    </mat-error>
+  </form>
+</div>
+

--- a/src/app/shared/zap-dialog/zap-dialog.component.scss
+++ b/src/app/shared/zap-dialog/zap-dialog.component.scss
@@ -1,0 +1,90 @@
+.mat-mdc-form-field {
+    display: inline;
+}
+
+.mat-mdc-dialog-actions {
+    display: flex;
+    justify-content: flex-end;
+}
+.zap-button {
+    background-color: #9c27b0;
+    color: white;
+}
+
+.profile-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 30px;
+  }
+  
+  .icon {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    overflow: hidden;
+    margin-right: 10px;
+  }
+  
+  .profile-image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border: unset;
+  }
+  
+  .name {
+    font-size: 18px;
+    font-weight: bold;
+    text-align: center;
+  }
+  
+  .emoji-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-bottom: 25px;
+  }
+  
+  .emoji-button {
+    margin: 0 18px;
+    border-radius: 15%;
+    background-color: #eee;
+    width: 21%;
+    height: 100%;
+  }
+  
+  .favorite-btn,
+  .thumb-up-btn,
+  .applause-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+  }
+  
+  // .favorite-btn:hover,
+  // .thumb-up-btn:hover,
+  // .applause-btn:hover
+  .emoji-button:hover {
+    background-color: #9c27b0;
+  }
+  
+  .mat-mdc-icon-button.mat-primary:hover {
+    color: white;
+  }
+
+  .favorite-btn .emoji-number,
+  .thumb-up-btn .emoji-number,
+  .applause-btn .emoji-number {
+    position: absolute;
+    right: -15px;
+    font-size: 14px;
+  }
+  
+ 
+
+  .mat-mdc-icon-button.mat-primary {
+    --mat-mdc-button-persistent-ripple-color: rgba(255, 255, 255, 0);
+    --mat-mdc-button-ripple-color: rgba(255, 255, 255, 0);
+  }

--- a/src/app/shared/zap-dialog/zap-dialog.component.spec.ts
+++ b/src/app/shared/zap-dialog/zap-dialog.component.spec.ts
@@ -1,0 +1,23 @@
+// import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+// import { ZapDialogComponent } from './zap-dialog.component';
+
+// describe('ZapDialogComponent', () => {
+//   let component: ZapDialogComponent;
+//   let fixture: ComponentFixture<ZapDialogComponent>;
+
+//   beforeEach(async () => {
+//     await TestBed.configureTestingModule({
+//       declarations: [ ZapDialogComponent ]
+//     })
+//     .compileComponents();
+
+//     fixture = TestBed.createComponent(ZapDialogComponent);
+//     component = fixture.componentInstance;
+//     fixture.detectChanges();
+//   });
+
+//   it('should create', () => {
+//     expect(component).toBeTruthy();
+//   });
+// });

--- a/src/app/shared/zap-dialog/zap-dialog.component.ts
+++ b/src/app/shared/zap-dialog/zap-dialog.component.ts
@@ -1,0 +1,223 @@
+import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
+import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+import { Event, getEventHash, Kind, UnsignedEvent, validateEvent, verifySignature } from 'nostr-tools';
+import { ApplicationState } from 'src/app/services/applicationstate';
+import { RelayService } from 'src/app/services/relay';
+import { EventService } from 'src/app/services/event';
+import { NostrService } from 'src/app/services/nostr';
+import { Utilities } from 'src/app/services/utilities';
+import { DataService } from 'src/app/services/data';
+import { ZapQrCodeComponent } from '../zap-qr-code/zap-qr-code.component';
+import { NostrProfileDocument, LNURLPayRequest, LNURLInvoice, NostrEventDocument } from 'src/app/services/interfaces';
+
+export interface ZapDialogData {
+  profile: NostrProfileDocument;
+}
+
+@Component({
+  selector: 'app-zap-dialog',
+  templateUrl: './zap-dialog.component.html',
+  styleUrls: ['./zap-dialog.component.scss']
+})
+export class ZapDialogComponent implements OnInit  {
+  sendZapForm!: UntypedFormGroup;
+  minSendable: number = 0;
+  maxSendable: number = 0;
+  profile!: NostrProfileDocument
+  amount: number = 0;
+  comment = "";
+  payRequest: LNURLPayRequest | null = null
+  invoice: LNURLInvoice = {
+    pr: ""
+  }
+
+  imagePath = '/assets/profile.png';
+  tooltip = '';
+  tooltipName = '';
+  profileName = '';
+  error: string = "";
+
+  constructor(@Inject(MAT_DIALOG_DATA) public data: ZapDialogData, 
+    private formBuilder: UntypedFormBuilder,
+    private eventService: EventService,
+    private relayService: RelayService,
+    private nostr: NostrService,
+    private util: Utilities,
+    private dataService: DataService,
+    private dialog: MatDialog,
+    public dialogRef: MatDialogRef<ZapDialogComponent>
+  ) {
+
+
+  }
+
+  async ngOnInit() {
+    this.profile = this.data.profile
+    this.sendZapForm = this.formBuilder.group({
+      amount: ['', [Validators.required]],
+      comment: ['']
+    })
+
+    this.fetchPayReq()
+    await this.updateProfileDetails();
+  }
+
+  async fetchPayReq(): Promise<void> {
+    this.payRequest = await this.fetchZapper() 
+    this.recofigureFormValidators()
+  }
+
+
+  async fetchZapper(): Promise<LNURLPayRequest | null> {
+    let staticPayReq = ""
+    if(this.profile.lud16) {
+      const parts = this.profile.lud16.split("@")
+      staticPayReq = `https://${parts[1]}/.well-known/lnurlp/${parts[0]}`;
+    } else if (this.profile.lud06 && this.profile.lud06.toLowerCase().startsWith("lnurl")) {
+      staticPayReq = this.util.convertBech32ToText(this.profile.lud06).toString()
+    }
+
+    if(staticPayReq.length !== 0) {
+      try {
+        const resp = await fetch(staticPayReq);
+        if(resp.ok) {
+          const payReq = await resp.json();
+          if(payReq.status === "ERROR") {
+            this.error = payReq.reason ? payReq.reason : "Error fetching the invoice - please try again later"
+          } else {
+            return payReq
+          }
+        }
+      } catch (err) {
+        this.error = "Error fetching the invoice - please try again later"
+      }
+    }
+
+    return null
+  }
+
+  async onSubmit() {
+    if (this.sendZapForm.valid) {
+      let comment = this.sendZapForm.get('comment')?.value
+      let amount = this.sendZapForm.get('amount')?.value
+      if(!amount || !this.payRequest) {
+        console.log( "error: please enter an amount and  a valid pay request")
+      } else {
+        const callback = new URL(this.payRequest.callback)
+        const query = new Map<string, string>()
+        query.set("amount", Math.floor(amount * 1000).toString())
+        if(comment && this.payRequest?.commentAllowed) {
+          query.set("comment", comment)
+        }
+      
+        let event; 
+        if(this.payRequest.nostrPubkey)
+        if(this.profile.pubkey) {
+          event = await this.createZapEvent(this.profile.pubkey, null, comment);
+          query.set("nostr", JSON.stringify(event))
+        }
+      
+        const baseUrl = `${callback.protocol}//${callback.host}${callback.pathname}`;
+        const queryJoined = [...query.entries()].map(val => `${val[0]}=${encodeURIComponent(val[1])}`).join("&");
+      
+        try {
+          const response = await fetch(`${baseUrl}?${queryJoined}`)
+          if(response.ok) {
+            const result = await response.json()
+            if(result.status === "ERROR") {
+              this.error = result.reason ? result.reason : "Error fetching the invoice - please try again later"
+            } else {
+              this.invoice = result
+              this.dialog.open(ZapQrCodeComponent, {
+                width: '400px',
+                data: { 
+                  invoice: this.invoice,
+                  profile: this.profile
+                }
+              })
+              this.dialogRef.close(ZapDialogComponent);
+            }
+          } else {
+            this.error = "Error fetching the invoice - please try again later"
+          }
+        } catch (err) {
+          this.error = "Error fetching the invoice - please try again later"
+        }
+      }
+    }
+  }
+  
+  async createZapEvent(targetPubKey: string, note?: any, msg?: string) {
+    let zapEvent = this.dataService.createEvent(Kind.Zap, '');
+
+    Object.assign([], zapEvent.tags);
+    if(note) {
+      zapEvent.tags.push(['e', note]);
+    }
+    zapEvent.tags.push(['p', targetPubKey]);
+    zapEvent.tags.push(['relays', ...Object.keys(this.relayService.relays)]);
+
+    const signedEvent = await this.createAndSignEvent(zapEvent);
+  
+    if (!signedEvent) {
+      return;
+    }
+  
+    return signedEvent;
+  
+  }
+
+  private async createAndSignEvent(originalEvent: UnsignedEvent) {
+    let signedEvent = originalEvent as Event;
+
+    signedEvent.id = getEventHash(originalEvent);
+    signedEvent = await this.nostr.sign(originalEvent);
+
+    const event = this.eventService.processEvent(signedEvent as NostrEventDocument);
+
+    if (!event) {
+      throw new Error('The event is not valid. Cannot publish.');
+    }
+
+    let ok = validateEvent(signedEvent);
+
+    if (!ok) {
+      throw new Error('The event is not valid. Cannot publish.');
+    }
+
+    let veryOk = await verifySignature(event as any);
+
+    if (!veryOk) {
+      throw new Error('The event signature not valid. Maybe you choose a different account than the one specified?');
+    }
+
+    return event;
+  }
+
+  private recofigureFormValidators() {
+    this.minSendable = (this.payRequest?.minSendable || 1000) / 1000
+    this.maxSendable = (this.payRequest?.maxSendable || 21_000_000_000) / 1000
+    this.sendZapForm.get('amount')?.setValidators([
+      Validators.min((this.payRequest?.minSendable || 1000) / 1000), 
+      Validators.max((this.payRequest?.maxSendable || 21_000_000_000) / 1000), 
+      Validators.required
+    ])
+  }
+
+  private async updateProfileDetails() {
+    if (!this.profile) {
+      return;
+    }
+    if (this.profile.picture) {
+      this.imagePath = this.profile.picture;
+    }
+    this.tooltip = this.profile.about;
+    this.tooltipName = this.profileName;
+    this.profileName = this.profile.display_name || this.profile.name || this.util.getNostrIdentifier(this.profile.pubkey);
+  }
+
+  setAmount(amount: number) {
+    this.sendZapForm.get('amount')?.setValue(amount)
+  }
+}

--- a/src/app/shared/zap-qr-code/zap-qr-code.component.html
+++ b/src/app/shared/zap-qr-code/zap-qr-code.component.html
@@ -1,0 +1,29 @@
+<div mat-dialog-content style="text-align: center;">
+    <div class="profile-container" style="display: inline-flex; align-items: center;">
+      <div class="icon icon-small" style="margin-right: 10px;">
+        <img
+          onerror="this.src='/assets/profile.png'"
+          *ngIf="profile?.status == 1 || profile?.status == 2"
+          class="profile-image profile-image-follow"
+          [matTooltip]="tooltip"
+          matTooltipPosition="above"
+          [src]="imagePath"
+        />
+        <img loading="lazy" onerror="this.src='/assets/profile.png'" *ngIf="profile?.status != 1 && profile?.status != 2" class="profile-image" [matTooltip]="tooltip" matTooltipPosition="above" [src]="imagePath" />
+      </div>
+      <div class="name clickable" style="flex-grow: 1;">
+        <span [class.muted]="profile.status == 2" [matTooltip]="tooltipName" matTooltipPosition="above">Send Zaps to {{ profileName }}</span>
+      </div>
+    </div>
+    <div style="display: flex; justify-content: center; align-items: center; flex-direction: column;">
+      <qrcode [qrdata]="invoice.pr" [width]="256" [errorCorrectionLevel]="'M'"></qrcode>
+      <div class="profile-labels" (click)="copy(invoice.pr)" style="display: flex; align-items: center; cursor: pointer;">
+        <div class="profile-labels-left">
+          <a class="hoverable" style="width: 100%;">{{ invoice.pr | slice:0:10 }}...{{ invoice.pr | slice:-10 }}</a>
+        </div>
+        <div class="profile-labels-middle dimmed" style="text-align: right;">
+          <mat-icon class="profile-icon" style="margin-left: 5px;">content_copy</mat-icon>
+        </div>
+      </div>
+    </div>
+  </div>

--- a/src/app/shared/zap-qr-code/zap-qr-code.component.scss
+++ b/src/app/shared/zap-qr-code/zap-qr-code.component.scss
@@ -1,0 +1,32 @@
+
+.profile-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 30px;
+  }
+  
+  .icon {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    overflow: hidden;
+    margin-right: 10px;
+  }
+  
+  .profile-image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border: unset;
+  }
+  
+  .name {
+    font-size: 18px;
+    font-weight: bold;
+    text-align: center;
+  }
+  
+  .mdc-dialog__actions {
+    padding: 0px;
+  }

--- a/src/app/shared/zap-qr-code/zap-qr-code.component.spec.ts
+++ b/src/app/shared/zap-qr-code/zap-qr-code.component.spec.ts
@@ -1,0 +1,23 @@
+// import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+// import { ZapQrCodeComponent } from './zap-qr-code.component';
+
+// describe('ZapQrCodeComponent', () => {
+//   let component: ZapQrCodeComponent;
+//   let fixture: ComponentFixture<ZapQrCodeComponent>;
+
+//   beforeEach(async () => {
+//     await TestBed.configureTestingModule({
+//       declarations: [ ZapQrCodeComponent ]
+//     })
+//     .compileComponents();
+
+//     fixture = TestBed.createComponent(ZapQrCodeComponent);
+//     component = fixture.componentInstance;
+//     fixture.detectChanges();
+//   });
+
+//   it('should create', () => {
+//     expect(component).toBeTruthy();
+//   });
+// });

--- a/src/app/shared/zap-qr-code/zap-qr-code.component.ts
+++ b/src/app/shared/zap-qr-code/zap-qr-code.component.ts
@@ -1,0 +1,53 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MatDialog, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { LNURLInvoice, NostrProfileDocument } from 'src/app/services/interfaces';
+import { Utilities } from 'src/app/services/utilities';
+
+export interface InvoiceQrCodeDialogData {
+  invoice: LNURLInvoice,
+  profile: NostrProfileDocument
+}
+
+@Component({
+  selector: 'app-zap-qr-code',
+  templateUrl: './zap-qr-code.component.html',
+  styleUrls: ['./zap-qr-code.component.scss']
+})
+export class ZapQrCodeComponent implements OnInit {
+  invoice: LNURLInvoice = {
+    pr: ""
+  }
+  profile!: NostrProfileDocument
+  imagePath = '/assets/profile.png';
+  tooltip = '';
+  tooltipName = '';
+  profileName = '';
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: InvoiceQrCodeDialogData,
+    private util: Utilities
+  ) {}
+
+  async ngOnInit() {
+    this.invoice = this.data.invoice
+    this.profile = this.data.profile
+    this.updateProfileDetails()
+  }
+
+
+
+  async updateProfileDetails() {
+    if (!this.profile) {
+      return;
+    }
+    if (this.profile.picture) {
+      this.imagePath = this.profile.picture;
+    }
+    this.tooltip = this.profile.about;
+    this.tooltipName = this.profileName;
+    this.profileName = this.profile.display_name || this.profile.name || this.profileName;
+  }
+
+  copy(text: string) {
+    this.util.copy(text);
+  }
+}


### PR DESCRIPTION
Now you can send zaps to profile, 
Here's a video that explains the UI:

[BlockCore zaps.webm](https://user-images.githubusercontent.com/19940301/222266207-449fa127-f1d3-4ebb-bd8d-809af2f6b3af.webm)

Future developments:
- Adding Zaps to posts
- Sending Anonymous and private Zaps