### PR TITLE
Allow tagging(mention) in Notes with username or display name

### DIFF
--- a/src/app/shared/content/content.ts
+++ b/src/app/shared/content/content.ts
@@ -298,6 +298,16 @@ export class ContentComponent {
         } else {
           i = res.push({ safeWord: this.utilities.sanitizeUrlAndBypass(token), word: token.substring(6), token: decoded.type });
         }
+      } else if (token.startsWith('@')) {
+        const username = token.substring(1);
+        const npub = this.profileService.following.find((follower) => follower.name === username)?.npub;
+        if (npub) {
+          const decoded = nip19.decode(npub);
+          const val = decoded.data as any;
+          i = res.push({ safeWord: this.utilities.sanitizeUrlAndBypass(token), word: val, token: decoded.type });
+        } else {
+          res[i] += token;
+        }
       } else if (token.startsWith('http://') || token.startsWith('https://')) {
         if (this.isImage(token)) {
           i = res.push({ safeWord: this.utilities.sanitizeUrlAndBypass(token), word: token, token: 'image' });


### PR DESCRIPTION
Fixes #136

As of now we can tag users by username only for whom we follow. Is it possible to lookup for users we don't follow ?

Here's how it works right now.  

https://github.com/block-core/blockcore-notes/assets/79367883/af3ee446-f48f-419b-99d7-56a562b4f97c


