### PR TITLE
Fix the features not working on  `Following` page

### DIFF
--- a/src/app/shared/profile-widget/profile-widget.html
+++ b/src/app/shared/profile-widget/profile-widget.html
@@ -1,4 +1,4 @@
 <div class="profile-widget">
   <app-event-header [pubkey]="pubkey"></app-event-header>
-  <app-profile-actions [pubkey]="pubkey"></app-profile-actions>
+  <app-profile-actions [pubkey]="pubkey" [profile]="profile"></app-profile-actions>
 </div>

--- a/src/app/shared/profile-widget/profile-widget.ts
+++ b/src/app/shared/profile-widget/profile-widget.ts
@@ -1,7 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { ProfileService } from 'src/app/services/profile';
 import { Utilities } from 'src/app/services/utilities';
-import { NostrProfile } from '../../services/interfaces';
+import { NostrProfile, NostrProfileDocument } from '../../services/interfaces';
 
 @Component({
   selector: 'app-profile-widget',
@@ -13,8 +13,13 @@ export class ProfileWidgetComponent {
 
   profileName = '';
   tooltip = '';
+  profile!: NostrProfileDocument;
 
   constructor(private profiles: ProfileService, private utilities: Utilities) {}
 
-  ngOnInit() {}
+  async ngOnInit() {
+    if(this.pubkey){
+      this.profile = await this.profiles.getProfile(this.pubkey)
+    }
+  }
 }


### PR DESCRIPTION
Fixes #141

While exploring in the code I found that in the `profile-action` all the methods were written with `profile!.pubkey` .

The flow is 

```
Following ---> Profile Widget ---> Profile Action
```

Here from the `following` only the **pubkeys** are passed so the **profile** doesn't exist for the `Profile Widget` and thus it never gets passed for `Profile Action`. So I have derived the profile from the pubkeys in the Profile Widget and passed it to the Profile Action and every feature then works perfectly fine as expected.